### PR TITLE
Feat: Added caching ticker search logic

### DIFF
--- a/finance_app/report_views.py
+++ b/finance_app/report_views.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 try:
     from src.rag.report_generator import ReportGenerator
     from src.utils.ticker_resolver import resolve_to_ticker
-    from src.utils.ticker_search_agent import search_tickers
+    from src.utils.supabase_helper import search_tickers
     from src.utils.pdf_utils import create_pdf
     from src.utils.plotly_charts import (
         generate_line_chart_plotly,

--- a/src/utils/supabase_helper.py
+++ b/src/utils/supabase_helper.py
@@ -23,6 +23,10 @@ def get_supabase_client() -> Client:
         return None
 
 
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
 def fetch_all_tickers():
     """Fetch all tickers from Supabase for local searching"""
     client = get_supabase_client()


### PR DESCRIPTION
- src\utils\supabase_helper.py
리포트 생성 페이지의 자동완성을 캐시하는 코드를 추가했습니다.
어떤 걸 기준으로, 어떻게 자동으로 캐시하는데, 안전하게 캐시할까 고민하다가,
어차피 몇만개 정도의 텍스트 데이터면 그냥 통째로 캐시하면 되잖아? 생각이 들어 그냥 db 전체를 캐시했습니다. (@lru_cache)

     **캐싱은 다음과 같이 동작합니다.** 
     1. 사용자가 검색어를 입력하는 즉시 db의 tickers 테이블에 있는 모든 데이터를 서버에 캐싱 (@lru_cache, 503개 기업 데이터, 0.83MB)
     2. 입력된 검색어로 메모리 조회, 텍스트가 바뀔 때마다 반복. (딜레이 거의 없음)
     3. 서버에 저장했기 때문에 서버를 끄지 않는 이상 유지되고 다른 사용자가 접속해도 db 불러오는 작업 없이 동작함
     4. ui/ux적으로는 응답이 빨라졌다! 외에 체감되는 변화 없이 완벽합니다.

- finance_app\report_views.py
search_tickers를 불러오는 import문이 잘못되어 있어 수정했습니다.