### PR TITLE
chore: CI/CD 배포를 위한 Dockerfile 및 .dockerignore 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Python / Django
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+
+# Environments
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+
+# DB
+db.sqlite3
+*.sqlite3
+
+# Git
+.git/
+.gitignore
+
+# Others
+.DS_Store
+*.log
+.vscode/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Python 3.12 슬림 이미지 사용 (README 권장 버전에 맞춤)
+FROM python:3.12-slim
+
+# 환경 변수 설정
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 시스템 의존성 설치 (빌드 및 DB 연결 등에 필요한 기본 패키지)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# 요구사항 파일 복사 및 의존성 설치
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install gunicorn
+
+# 프로젝트 코드 전체 복사 (.dockerignore에서 불필요한 파일 제외)
+COPY . /app/
+
+# 포트 노출
+EXPOSE 8000
+
+# WSGI 앱으로 Gunicorn 배포용 서버 실행
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "config.wsgi:application"]

--- a/finance_app/report_views.py
+++ b/finance_app/report_views.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 try:
     from src.rag.report_generator import ReportGenerator
     from src.utils.ticker_resolver import resolve_to_ticker
-    from src.utils.ticker_search_agent import search_tickers
+    from src.utils.supabase_helper import search_tickers
     from src.utils.pdf_utils import create_pdf
     from src.utils.plotly_charts import (
         generate_line_chart_plotly,


### PR DESCRIPTION
## 📝 작업 내용 (Changes)
- CI/CD 배포 파이프라인 구축을 위한 도커 컨테이너화 작업
- 운영 환경(Production)을 위한 Dockerfile (Python 3.12 slim, Gunicorn 기반) 추가
- 불필요한 빌드 컨텍스트 캐싱 및 용량 절감을 위한 [.dockerignore] 파일 추가
- [search_tickers]
- 임포트 누락/오류 버그 수정 (`src.utils.ticker_search_agent` -> `src.utils.supabase_helper`로 경로 정정)

