### PR TITLE
feat(auth): 소셜 로그인(Kakao, Google, Naver, GitHub) 연동 및 UI 구현 #21

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -41,7 +41,15 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     "finance_app",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "allauth.socialaccount.providers.google",
+    "allauth.socialaccount.providers.github",
+    "allauth.socialaccount.providers.kakao",
+    "allauth.socialaccount.providers.naver",
 ]
 
 MIDDLEWARE = [
@@ -52,6 +60,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -135,3 +144,45 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGIN_URL = "/accounts/login/"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
+
+SITE_ID = 1
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+# Allauth Settings
+ACCOUNT_LOGIN_METHODS = {'username', 'email'}
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'APP': {
+            'client_id': os.getenv('GOOGLE_CLIENT_ID', ''),
+            'secret': os.getenv('GOOGLE_CLIENT_SECRET', ''),
+            'key': ''
+        }
+    },
+    'github': {
+        'APP': {
+            'client_id': os.getenv('GITHUB_CLIENT_ID', ''),
+            'secret': os.getenv('GITHUB_CLIENT_SECRET', ''),
+            'key': ''
+        }
+    },
+    'kakao': {
+        'APP': {
+            'client_id': os.getenv('KAKAO_CLIENT_ID', ''),
+            'secret': os.getenv('KAKAO_CLIENT_SECRET', ''),
+            'key': ''
+        }
+    },
+    'naver': {
+        'APP': {
+            'client_id': os.getenv('NAVER_CLIENT_ID', ''),
+            'secret': os.getenv('NAVER_CLIENT_SECRET', ''),
+            'key': ''
+        }
+    }
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path(
         "accounts/", include("django.contrib.auth.urls")
     ),  # Provides login, logout, etc.
+    path("accounts/", include("allauth.urls")), # Social login URLs
     path("", include("finance_app.urls")),
 ]

--- a/finance_app/templates/finance_app/signup.html
+++ b/finance_app/templates/finance_app/signup.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load socialaccount %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center" style="min-height: 80vh;">
@@ -11,66 +12,120 @@
 
         <form method="post">
             {% csrf_token %}
+            {% if form.non_field_errors %}
+            <div class="alert alert-danger" role="alert">
+                {% for error in form.non_field_errors %}
+                {{ error }}
+                {% endfor %}
+            </div>
+            {% endif %}
+
             {% for field in form %}
-                <div class="mb-3">
-                    <label for="{{ field.id_for_label }}" class="form-label text-light fw-semibold">{{ field.label }}</label>
-                    <div class="input-group">
-                        {{ field }}
-                    </div>
-                    {% if field.help_text %}
-                        <div class="form-text text-secondary small mt-1">{{ field.help_text|safe }}</div>
-                    {% endif %}
-                    {% for error in field.errors %}
-                        <div class="text-danger small mt-1">{{ error }}</div>
-                    {% endfor %}
+            <div class="mb-3">
+                <label for="{{ field.id_for_label }}" class="form-label text-light fw-semibold">
+                    {{ field.label }}
+                </label>
+                <div class="input-group">
+                    {{ field }}
                 </div>
+                {% if field.help_text %}
+                <div class="form-text text-secondary small mt-1">{{ field.help_text|safe }}</div>
+                {% endif %}
+                {% for error in field.errors %}
+                <div class="text-danger small mt-1">{{ error }}</div>
+                {% endfor %}
+            </div>
             {% endfor %}
 
             <div class="d-grid mt-4">
                 <button type="submit" class="btn btn-premium btn-lg fw-bold">가입하기</button>
             </div>
-            
-            <div class="text-center mt-4">
-                <span class="text-muted">이미 계정이 있으신가요?</span>
-                <a href="{% url 'login' %}" class="text-primary-accent text-decoration-none ms-2 fw-semibold">로그인</a>
-            </div>
         </form>
+
+        <div class="text-center mt-4 mb-3">
+            <span class="text-muted small">또는 소셜 계정으로 가입</span>
+        </div>
+
+        <div class="d-flex justify-content-center gap-2 mb-4">
+            <form action="{% provider_login_url 'google' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit"
+                    class="btn btn-outline-light rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0;" title="Google">
+                    <i class="bi bi-google fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'github' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit"
+                    class="btn btn-outline-light rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0;" title="GitHub">
+                    <i class="bi bi-github fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'kakao' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit" class="btn rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0; background-color: #FEE500; border-color: #FEE500; color: #000;"
+                    title="Kakao">
+                    <i class="bi bi-chat-fill fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'naver' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit" class="btn rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0; background-color: #03C75A; border-color: #03C75A; color: #fff;"
+                    title="Naver">
+                    <span class="fs-5 fw-bold font-monospace" style="line-height: 1;">N</span>
+                </button>
+            </form>
+        </div>
+
+        <div class="text-center mt-3">
+            <span class="text-muted">이미 계정이 있으신가요?</span>
+            <a href="{% url 'login' %}" class="text-primary-accent text-decoration-none ms-2 fw-semibold">로그인</a>
+        </div>
     </div>
 </div>
 
 <style>
-/* 폼 입력창 스타일링 오버라이드 (Premium Dark 테마 연동) */
-.premium-card input, .premium-card select {
-    background-color: var(--bg-main) !important;
-    color: var(--text-primary) !important;
-    border: 1px solid var(--border-color) !important;
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    width: 100%;
-}
-.premium-card input:focus {
-    box-shadow: var(--shadow-glow-blue) !important;
-    border-color: var(--accent-blue) !important;
-    outline: none;
-}
-/* Django Form Help Text Styling */
-.helptext {
-    list-style: none;
-    padding-left: 0;
-    margin-bottom: 0;
-    margin-top: 0.5rem;
-}
-.helptext li {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-    margin-bottom: 0.25rem;
-}
-.helptext li::before {
-    content: "•";
-    color: var(--accent-blue);
-    display: inline-block;
-    width: 1em;
-    margin-left: -1em;
-}
+    /* 폼 입력창 스타일링 오버라이드 (Premium Dark 테마 연동) */
+    .premium-card input,
+    .premium-card select {
+        background-color: var(--bg-main) !important;
+        color: var(--text-primary) !important;
+        border: 1px solid var(--border-color) !important;
+        border-radius: 8px;
+        padding: 0.75rem 1rem;
+        width: 100%;
+    }
+
+    .premium-card input:focus {
+        box-shadow: var(--shadow-glow-blue) !important;
+        border-color: var(--accent-blue) !important;
+        outline: none;
+    }
+
+    /* Django Form Help Text Styling */
+    .helptext {
+        list-style: none;
+        padding-left: 0;
+        margin-bottom: 0;
+        margin-top: 0.5rem;
+    }
+
+    .helptext li {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .helptext li::before {
+        content: "•";
+        color: var(--accent-blue);
+        display: inline-block;
+        width: 1em;
+        margin-left: -1em;
+    }
 </style>
 {% endblock %}

--- a/finance_app/templates/registration/login.html
+++ b/finance_app/templates/registration/login.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load socialaccount %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center" style="min-height: 80vh;">
@@ -11,77 +12,123 @@
 
         <form method="post" action="{% url 'login' %}">
             {% csrf_token %}
-            
+
             {% if form.non_field_errors %}
-                <div class="alert alert-danger mb-4">
-                    {% for error in form.non_field_errors %}
-                        {{ error }}
-                    {% endfor %}
-                </div>
+            <div class="alert alert-danger mb-4">
+                {% for error in form.non_field_errors %}
+                {{ error }}
+                {% endfor %}
+            </div>
             {% endif %}
 
             {% for field in form %}
-                <div class="mb-3">
-                    <label for="{{ field.id_for_label }}" class="form-label text-light fw-semibold">{{ field.label }}</label>
-                    <div class="input-group">
-                        {{ field }}
-                    </div>
-                    {% if field.help_text %}
-                        <div class="form-text text-secondary small mt-1">{{ field.help_text|safe }}</div>
-                    {% endif %}
-                    {% for error in field.errors %}
-                        <div class="text-danger small mt-1">{{ error }}</div>
-                    {% endfor %}
+            <div class="mb-3">
+                <label for="{{ field.id_for_label }}" class="form-label text-light fw-semibold">
+                    {{ field.label }}
+                </label>
+                <div class="input-group">
+                    {{ field }}
                 </div>
+                {% if field.help_text %}
+                <div class="form-text text-secondary small mt-1">{{ field.help_text|safe }}</div>
+                {% endif %}
+                {% for error in field.errors %}
+                <div class="text-danger small mt-1">{{ error }}</div>
+                {% endfor %}
+            </div>
             {% endfor %}
 
             <div class="d-grid mt-4">
                 <button type="submit" class="btn btn-premium btn-lg fw-bold">로그인</button>
             </div>
-            
-            <div class="text-center mt-4">
-                <span class="text-muted">계정이 없으신가요?</span>
-                <a href="{% url 'finance_app:signup' %}" class="text-primary-accent text-decoration-none ms-2 fw-semibold">회원가입</a>
-            </div>
-            
             <input type="hidden" name="next" value="{{ next|default:'/' }}">
         </form>
+
+        <div class="text-center mt-4 mb-3">
+            <span class="text-muted small">또는 소셜 계정으로 로그인</span>
+        </div>
+
+        <div class="d-flex justify-content-center gap-2 mb-4">
+            <form action="{% provider_login_url 'google' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit"
+                    class="btn btn-outline-light rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0;" title="Google">
+                    <i class="bi bi-google fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'github' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit"
+                    class="btn btn-outline-light rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0;" title="GitHub">
+                    <i class="bi bi-github fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'kakao' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit" class="btn rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0; background-color: #FEE500; border-color: #FEE500; color: #000;"
+                    title="Kakao">
+                    <i class="bi bi-chat-fill fs-5"></i>
+                </button>
+            </form>
+            <form action="{% provider_login_url 'naver' %}" method="post" class="m-0">
+                {% csrf_token %}
+                <button type="submit" class="btn rounded-circle d-flex justify-content-center align-items-center"
+                    style="width: 45px; height: 45px; padding: 0; background-color: #03C75A; border-color: #03C75A; color: #fff;"
+                    title="Naver">
+                    <span class="fs-5 fw-bold font-monospace" style="line-height: 1;">N</span>
+                </button>
+            </form>
+        </div>
+
+        <div class="text-center mt-3">
+            <span class="text-muted">계정이 없으신가요?</span>
+            <a href="{% url 'finance_app:signup' %}"
+                class="text-primary-accent text-decoration-none ms-2 fw-semibold">회원가입</a>
+        </div>
     </div>
 </div>
 
 <style>
-/* 폼 입력창 스타일링 오버라이드 (Premium Dark 테마 연동) */
-.premium-card input, .premium-card select {
-    background-color: var(--bg-main) !important;
-    color: var(--text-primary) !important;
-    border: 1px solid var(--border-color) !important;
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    width: 100%;
-}
-.premium-card input:focus {
-    box-shadow: var(--shadow-glow-blue) !important;
-    border-color: var(--accent-blue) !important;
-    outline: none;
-}
-/* Django Form Help Text Styling */
-.helptext {
-    list-style: none;
-    padding-left: 0;
-    margin-bottom: 0;
-    margin-top: 0.5rem;
-}
-.helptext li {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-    margin-bottom: 0.25rem;
-}
-.helptext li::before {
-    content: "•";
-    color: var(--accent-blue);
-    display: inline-block;
-    width: 1em;
-    margin-left: -1em;
-}
+    /* 폼 입력창 스타일링 오버라이드 (Premium Dark 테마 연동) */
+    .premium-card input,
+    .premium-card select {
+        background-color: var(--bg-main) !important;
+        color: var(--text-primary) !important;
+        border: 1px solid var(--border-color) !important;
+        border-radius: 8px;
+        padding: 0.75rem 1rem;
+        width: 100%;
+    }
+
+    .premium-card input:focus {
+        box-shadow: var(--shadow-glow-blue) !important;
+        border-color: var(--accent-blue) !important;
+        outline: none;
+    }
+
+    /* Django Form Help Text Styling */
+    .helptext {
+        list-style: none;
+        padding-left: 0;
+        margin-bottom: 0;
+        margin-top: 0.5rem;
+    }
+
+    .helptext li {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .helptext li::before {
+        content: "•";
+        color: var(--accent-blue);
+        display: inline-block;
+        width: 1em;
+        margin-left: -1em;
+    }
 </style>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ sentence-transformers
 rank_bm25
 tf-keras
 django
+django-allauth[socialaccount]


### PR DESCRIPTION
📋 작업 상세 내용

- 소셜 로그인 기능 (OAuth2) 신규 추가
  - django-allauth를 사용하여 백엔드-플랫폼 간 인증 절차 구현
  - Google, Kakao, Naver, GitHub API 키 연동 (개발 환경 적용 완료)
  - 사용자가 소셜 버튼 클릭 시 auth_user 테이블에 계정 자동 생성 및 연동되도록 세팅
- 프론트엔드 로그인/회원가입 디자인 개편
  - 서비스의 다크 테마(Glassmorphism)에 어울리는 소셜 로그인 버튼 리스트 추가
  - 장고 폼(Django Form)이 그려질 때 라벨 필드가 깨지던 문제 수정 ({{ field.label_tag|striptags }})
- 기타 작업 내역
  - 사이트(localhost:8000) 도메인 설정 반영하여 카카오 API 에러 시나리오(KOE006, KOE008) 해결