### PR TITLE
update: 카카오 아이디 로그인시 메일 요청 삭제

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -214,7 +214,7 @@ LOGGING = {
 # Social Account Provider specific settings
 SOCIALACCOUNT_PROVIDERS['kakao']['SCOPE'] = ['profile_nickname', 'account_email']
 SOCIALACCOUNT_PROVIDERS['google']['SCOPE'] = ['profile', 'email']
-SOCIALACCOUNT_PROVIDERS['naver']['SCOPE'] = ['name', 'email']
+SOCIALACCOUNT_PROVIDERS['naver']['SCOPE'] = ['name']
 SOCIALACCOUNT_PROVIDERS['github']['SCOPE'] = ['user:email', 'read:user']
 
 # To populate user models from provider


### PR DESCRIPTION
설정하지 않은 카카오 로그인 동의 항목을 포함해 인가 코드를 요청했습니다.
설정하지 않은 동의 항목: account_email
오류

로그인시 이메일을 띄워주려했으나, 비즈니스 채널 문제로 불가능 해당 기능 삭제