### PR TITLE
Feat: 캐시 사라지는 문제 해결

### DIFF
--- a/finance_app/views.py
+++ b/finance_app/views.py
@@ -181,8 +181,8 @@ def home(request):
         "db_companies_sample": results["db_companies_sample"],
     }
 
-    # 3. 데이터 캐싱 (600초 = 10분)
-    cache.set(cache_key, context, 600)
+    # 3. 데이터 캐싱 (무기한)
+    cache.set(cache_key, context, None)
 
     return render(request, "finance_app/home.html", context)
 


### PR DESCRIPTION
지금껏 views.py의 home 함수에서
cache.set(cache_key, context, 600) 으로 설정해
대시보드의 환율 등의 정보들이 10분 지날때 마다 새로 받아와서 오래 걸리는 거 였습니다.
none로 바꿔버렸습니다. 이제 서버 시작할 때만 불러옵니다.